### PR TITLE
The extraction of MATLAB version

### DIFF
--- a/tool/myunique.m
+++ b/tool/myunique.m
@@ -7,8 +7,11 @@ function [sortA,i2,j] = myunique(A)
 %
 % Copyright (C) Long Chen. See COPYRIGHT.txt for details.
 
-matlabversion = extractBetween(version,"(",")");
-if str2double(matlabversion{1}(2:end-1)) <= 2012
+matlabversion = version;
+startIndex = regexp(version,'(')+2;
+endIndex = regexp(version, ')')-2;
+
+if str2double(matlabversion(startIndex:endIndex)) <= 2012
     [sortA, i2, j] = unique(A,'rows');
 else
     [sortA, i2, j] = unique(A,'rows','legacy');

--- a/tool/myunique.m
+++ b/tool/myunique.m
@@ -7,9 +7,9 @@ function [sortA,i2,j] = myunique(A)
 %
 % Copyright (C) Long Chen. See COPYRIGHT.txt for details.
 
-matlabversion = version;
-if str2double(matlabversion(end-5:end-2)) <= 2012
-    [sortA, i2, j] = unique(A,'rows');
+matlabversion = extractBetween(version,"(",")");
+if str2double(matlabversion{1}(2:end-1)) > 2012
+    [edge, i2, j] = unique(allEdge,'rows','legacy'); %#ok<ASGLU>
 else
-    [sortA, i2, j] = unique(A,'rows','legacy'); %#ok<*ASGLU>
+    [edge, i2, j] = unique(allEdge,'rows'); %#ok<ASGLU>
 end

--- a/tool/myunique.m
+++ b/tool/myunique.m
@@ -8,8 +8,8 @@ function [sortA,i2,j] = myunique(A)
 % Copyright (C) Long Chen. See COPYRIGHT.txt for details.
 
 matlabversion = extractBetween(version,"(",")");
-if str2double(matlabversion{1}(2:end-1)) > 2012
-    [edge, i2, j] = unique(allEdge,'rows','legacy'); %#ok<ASGLU>
+if str2double(matlabversion{1}(2:end-1)) <= 2012
+    [sortA, i2, j] = unique(A,'rows');
 else
-    [edge, i2, j] = unique(allEdge,'rows'); %#ok<ASGLU>
+    [sortA, i2, j] = unique(A,'rows','legacy');
 end


### PR DESCRIPTION
Some MATLAB version has "Update #" at the end, which results in wrong extraction of version number. This change uses parentheses to locate the year.