### PR TITLE
fix isBdNode not assigned a value bug

### DIFF
--- a/solver/gradmatrix.m
+++ b/solver/gradmatrix.m
@@ -24,7 +24,6 @@ s = [-ones(NE,1),ones(NE,1)];
 isBdNode = false(N,1);
 if any(isBdEdge) % no grad on boundary edges
     bdEdge = edge(isBdEdge,:);
-    isBdNode = false(N,1);
     isBdNode(bdEdge(:)) = true;
     idx = ~(isBdEdge(i) | isBdNode(j)); 
 else

--- a/solver/gradmatrix.m
+++ b/solver/gradmatrix.m
@@ -21,6 +21,7 @@ NE = size(edge,1); N  = double(max(edge(:)));
 i = repmat((1:NE)',2,1);
 j = double(edge(:));
 s = [-ones(NE,1),ones(NE,1)];
+isBdNode = false(N,1);
 if any(isBdEdge) % no grad on boundary edges
     bdEdge = edge(isBdEdge,:);
     isBdNode = false(N,1);


### PR DESCRIPTION
when I run the example\fem\Maxwell\Maxwell3ND0femrate.m, the fellowing error will appear
```
Output argument "isBdNode" (and possibly others) not assigned a value in
the execution with "gradmatrix" function.

Error in mgMaxwell (line 79)
[grad,isBdNode] = gradmatrix(edge,isBdEdge);

Error in Maxwell (line 393)
    [u,info] = mgMaxwell(bigAD,f,AP,node,elemold,edge,HB,option);

Error in femMaxwell3 (line 60)
                [u,edge,eqn,info] = Maxwell(node,elem,bdFlag,pde,option);

Error in Maxwell3ND0femrate (line 39)
femMaxwell3(mesh,pde,option);
```
this error will be resolved when I make the following changes to the file solver/gradmatrix.m